### PR TITLE
Added support to ach_credit_transfer payment methods

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -275,6 +275,54 @@ module StripeMock
       }, params)
     end
 
+    def self.mock_ach_credit_transfer(params={})
+      currency = params[:currency] || StripeMock.default_currency
+      {
+        id: 'src_test_ach_transfer',
+        object: 'source',
+        ach_credit_transfer: {
+          account_number: 'test_413658ce3cdd',
+          routing_number: '110000000',
+          fingerprint: 'SceoQ3FO67uf3b8c',
+          swift_code: 'TSTEZ122',
+          bank_name: 'TEST BANK',
+          refund_routing_number: nil,
+          refund_account_holder_type: nil,
+          refund_account_holder_name: nil
+        },
+        amount: nil,
+        client_secret: 'src_client_secret_aaaaa',
+        created: 1653441407,
+        currency: currency,
+        customer: 'c_test_customer',
+        flow: 'receiver',
+        livemode: false,
+        metadata: {},
+        owner: {
+          address: nil,
+          email: 'amount_0@stripe.com',
+          name: nil,
+          phone: nil,
+          verified_address: nil,
+          verified_email: nil,
+          verified_name: nil,
+          verified_phone: nil
+        },
+        receiver: {
+          address: '110000000-test_413658ce3cdd',
+          amount_charged: 0,
+          amount_received: 0,
+          amount_returned: 0,
+          refund_attributes_method: 'email',
+          refund_attributes_status: 'missing'
+        },
+        statement_descriptor: nil,
+        status: 'pending',
+        type: 'ach_credit_transfer',
+        usage: 'reusable'
+      }.merge(params)
+    end
+
     def self.mock_bank_account(params={})
       currency = params[:currency] || StripeMock.default_currency
       {
@@ -1190,6 +1238,10 @@ module StripeMock
     end
 
     def self.source_to_payment_method(source={})
+      if source[:object] == "source" && source[:ach_credit_transfer].present?
+        return Data.mock_ach_credit_transfer_payment_method(source)
+      end
+
       params = {
         id: source[:id],
         card: source, customer: source[:customer], metadata: source[:metadata],
@@ -1199,6 +1251,54 @@ module StripeMock
         }
       }
       Data.mock_payment_method(params)
+    end
+    
+    def self.mock_ach_credit_transfer_payment_method(params = {})
+      payment_method_id = params[:id] || "src_1L38qBEm9XYVHykjLMIpRxfe"
+      {
+        id: payment_method_id,
+        object: "source",
+        type: "ach_credit_transfer",
+        ach_credit_transfer: {
+          account_number: "test_413658ce3cdd",
+          routing_number: "110000000",
+          fingerprint: "SceoQ3FO67uf3b8c",
+          swift_code: "TSTEZ122",
+          bank_name: "TEST BANK",
+          refund_routing_number: nil,
+          refund_account_holder_type: nil,
+          refund_account_holder_name: nil
+        },
+        amount: nil,
+        client_secret: "src_client_secret_SrqTUKKMHBSkDJzWOi0FYXL4",
+        created: 1653441407,
+        currency: "usd",
+        customer: params[:customer] || nil,
+        flow: "receiver",
+        livemode: false,
+        metadata: {},
+        owner: {
+          address: nil,
+          email: "amount_0@stripe.com",
+          name: nil,
+          phone: nil,
+          verified_address: nil,
+          verified_email: nil,
+          verified_name: nil,
+          verified_phone: nil
+        },
+        receiver: {
+          address: "110000000-test_413658ce3cdd",
+          amount_charged: 0,
+          amount_received: 0,
+          amount_returned: 0,
+          refund_attributes_method: "email",
+          refund_attributes_status: "missing"
+        },
+        statement_descriptor: nil,
+        status: "pending",
+        usage: "reusable"
+      }.merge(params)
     end
 
     def self.mock_payment_method(params = {})

--- a/lib/stripe_mock/instance.rb
+++ b/lib/stripe_mock/instance.rb
@@ -64,6 +64,7 @@ module StripeMock
       @balance = Data.mock_balance
       @balance_transactions = Data.mock_balance_transactions(['txn_05RsQX2eZvKYlo2C0FRTGSSA','txn_15RsQX2eZvKYlo2C0ERTYUIA', 'txn_25RsQX2eZvKYlo2C0ZXCVBNM', 'txn_35RsQX2eZvKYlo2C0QAZXSWE', 'txn_45RsQX2eZvKYlo2C0EDCVFRT', 'txn_55RsQX2eZvKYlo2C0OIKLJUY', 'txn_65RsQX2eZvKYlo2C0ASDFGHJ', 'txn_75RsQX2eZvKYlo2C0EDCXSWQ', 'txn_85RsQX2eZvKYlo2C0UJMCDET', 'txn_95RsQX2eZvKYlo2C0EDFRYUI'])
       @bank_tokens = {}
+      @ach_credit_transfer_tokens = {}
       @card_tokens = {}
       @customers = {}
       @charges = {}

--- a/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/card_helpers.rb
@@ -94,6 +94,8 @@ module StripeMock
         source =
           if params[:card]
             card_from_params(params[:card])
+          elsif params[:ach_credit_transfer]
+            get_ach_credit_transfer_by_token(params[:ach_credit_transfer])
           elsif params[:bank_account]
             get_bank_by_token(params[:bank_account])
           else

--- a/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/token_helpers.rb
@@ -23,6 +23,14 @@ module StripeMock
           @bank_tokens.delete(token)
         end
       end
+      
+      def get_ach_credit_transfer_by_token(token)
+        if token.nil? || @ach_credit_transfer_tokens[token].nil?
+          Data.mock_ach_credit_transfer
+        else
+          @ach_credit_transfer_tokens.delete(token)
+        end
+      end
 
       def get_card_by_token(token)
         if token.nil? || @card_tokens[token].nil?


### PR DESCRIPTION
The current patched version only supports CARDS and BANK ACCOUNTS.

This changes makes possible to add a ach_credit_transfer as a source/payment method.
Also brings it outside of the `cards` key. Same behavior as last version of the Stripe API (https://stripe.com/docs/upgrades#2020-08-27).